### PR TITLE
Fix `long` option when creating tar

### DIFF
--- a/src/tar-utils.ts
+++ b/src/tar-utils.ts
@@ -51,8 +51,8 @@ export async function createTar(
     compressionMethod === CompressionMethod.GZIP
       ? ['-z']
       : compressionMethod === CompressionMethod.ZSTD_WITHOUT_LONG
-      ? ['--use-compress-program', 'zstd -T0 --long=30']
-      : ['--use-compress-program', 'zstd -T0'];
+      ? ['--use-compress-program', 'zstd -T0']
+      : ['--use-compress-program', 'zstd -T0 --long=30'];
 
   await exec.exec('tar', [
     '-c',


### PR DESCRIPTION
See Github Action cache: https://github.com/actions/toolkit/blob/15e23998268e31520e3d93cbd106bd3228dea77f/packages/cache/src/internal/tar.ts#L108